### PR TITLE
Use PWM to read MHZ19B sensor

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -38,17 +38,10 @@
 
 // PIN of the LED used to signal to the user.
 #define SIGNAL_LED_PIN 4
-
 // PIN of the DHT11 sensor.
 #define DHT11_PIN 32
-
-// Serial for the MHZ19 sensor.
-#define MHZ19_SERIAL Serial2
-// Serial Baud Rate for the MHZ19 sensor.
-#define MHZ19_BAUD_RATE 9600
-// PINs of the MHZ19 sensor.
-#define MHZ19_RX 16
-#define MHZ19_TX 17
+// PWM PIN for the MHZ19 sensor.
+#define MHZ19B_PWM_PIN 16
 
 // InfluxDB settings.
 #define HAS_INFLUXDB


### PR DESCRIPTION
This PR proposes to use the PWM protocol to read the CO2 value from the MHZ19B sensor instead of the Hardware Serial.
After some experimentations we noticed that the Hardware Serial sometimes had some interference that caused it to lose the packages and result in a value read wrong (too high or too low); on the other hand, the PWM seems to be more stable and leads to much consistent values.