### PR TITLE
Add ability to set offset for each value read form the sensor

### DIFF
--- a/src/board_preference.cpp
+++ b/src/board_preference.cpp
@@ -31,6 +31,11 @@ bool BoardPreference::init() {
   app_infoln("Device Room:        '" + get_board_room() + "'");
   app_infoln("Spoofed MAC:        '" + get_spoofed_mac() + "'");
   app_infoln("Temp Offset:        '" + String(get_temperature_offset()) + "'");
+  app_infoln("Hum Offset:         '" + String(get_humidity_offset()) + "'");
+  app_infoln("CO2 Offset:         '" + String(get_co2_offset()) + "'");
+  app_infoln("eCO2 Offset:        '" + String(get_eco2_offset()) + "'");
+  app_infoln("TVOC Offset:        '" + String(get_tvoc_offset()) + "'");
+  app_infoln("PM 10 Offset:       '" + String(get_pm10_offset()) + "'");
   app_infoln("Reboot Count:       '" + String(get_reboot_count()) + "'");
 
   return true;
@@ -44,6 +49,11 @@ bool BoardPreference::clear() {
   _board_room              = "";
   _spoofed_mac_addr        = "";
   _temperature_offset      = 0;
+  _humidity_offset         = 0;
+  _co2_offset              = 0;
+  _eco2_offset             = 0;
+  _tvoc_offset             = 0;
+  _pm10_offset             = 0;
   _reboot_count            = 0;
 
   return write_preferences();
@@ -111,8 +121,33 @@ bool BoardPreference::set_spoofed_mac(String mac) {
   return write_preferences();
 }
 
-bool BoardPreference::set_temperature_offset(int offset) {
-  _temperature_offset = (uint8_t)offset;
+bool BoardPreference::set_temperature_offset(int16_t offset) {
+  _temperature_offset = offset;
+  return write_preferences();
+}
+
+bool BoardPreference::set_humidity_offset(int16_t offset) {
+  _humidity_offset = offset;
+  return write_preferences();
+}
+
+bool BoardPreference::set_co2_offset(int16_t offset) {
+  _co2_offset = offset;
+  return write_preferences();
+}
+
+bool BoardPreference::set_eco2_offset(int16_t offset) {
+  _eco2_offset = offset;
+  return write_preferences();
+}
+
+bool BoardPreference::set_tvoc_offset(int16_t offset) {
+  _tvoc_offset = offset;
+  return write_preferences();
+}
+
+bool BoardPreference::set_pm10_offset(int16_t offset) {
+  _pm10_offset = offset;
   return write_preferences();
 }
 
@@ -163,10 +198,25 @@ bool BoardPreference::read_preferences() {
   _spoofed_mac_addr = EEPROM.readString(addr);
   addr += _spoofed_mac_addr.length() + 1;
   app_debugln("BoardPreference::read_preferences: _spoofed_mac_addr: '" + _spoofed_mac_addr + "'");
-  _temperature_offset = EEPROM.readByte(addr);
-  addr += sizeof(uint8_t);
+  _temperature_offset = EEPROM.readShort(addr);
+  addr += sizeof(int16_t);
   app_debugln("BoardPreference::read_preferences: _temperature_offset: "
               + String(_temperature_offset));
+  _humidity_offset = EEPROM.readShort(addr);
+  addr += sizeof(int16_t);
+  app_debugln("BoardPreference::read_preferences: _humidity_offset: " + String(_humidity_offset));
+  _co2_offset = EEPROM.readShort(addr);
+  addr += sizeof(int16_t);
+  app_debugln("BoardPreference::read_preferences: _co2_offset: " + String(_co2_offset));
+  _eco2_offset = EEPROM.readShort(addr);
+  addr += sizeof(int16_t);
+  app_debugln("BoardPreference::read_preferences: _eco2_offset: " + String(_eco2_offset));
+  _tvoc_offset = EEPROM.readShort(addr);
+  addr += sizeof(int16_t);
+  app_debugln("BoardPreference::read_preferences: _tvoc_offset: " + String(_tvoc_offset));
+  _pm10_offset = EEPROM.readShort(addr);
+  addr += sizeof(int16_t);
+  app_debugln("BoardPreference::read_preferences: _pm10_offset: " + String(_pm10_offset));
   _reboot_count = EEPROM.readUShort(addr);
   addr += sizeof(uint16_t);
   app_debugln("BoardPreference::read_preferences: _reboot_count: " + String(_reboot_count));
@@ -212,8 +262,18 @@ bool BoardPreference::write_preferences() {
   addr += _board_room.length() + 1;
   EEPROM.writeString(addr, _spoofed_mac_addr);
   addr += _spoofed_mac_addr.length() + 1;
-  EEPROM.writeByte(addr, _temperature_offset);
-  addr += sizeof(uint8_t);
+  EEPROM.writeShort(addr, _temperature_offset);
+  addr += sizeof(int16_t);
+  EEPROM.writeShort(addr, _humidity_offset);
+  addr += sizeof(int16_t);
+  EEPROM.writeShort(addr, _co2_offset);
+  addr += sizeof(int16_t);
+  EEPROM.writeShort(addr, _eco2_offset);
+  addr += sizeof(int16_t);
+  EEPROM.writeShort(addr, _tvoc_offset);
+  addr += sizeof(int16_t);
+  EEPROM.writeShort(addr, _pm10_offset);
+  addr += sizeof(int16_t);
   EEPROM.writeUShort(addr, _reboot_count);
   addr += sizeof(uint16_t);
 
@@ -233,6 +293,11 @@ void BoardPreference::create_checksum_prefs_buffer() {
   _checksum_buffer_sz += _board_room.length();
   _checksum_buffer_sz += _spoofed_mac_addr.length();
   _checksum_buffer_sz += sizeof(_temperature_offset);
+  _checksum_buffer_sz += sizeof(_humidity_offset);
+  _checksum_buffer_sz += sizeof(_co2_offset);
+  _checksum_buffer_sz += sizeof(_eco2_offset);
+  _checksum_buffer_sz += sizeof(_tvoc_offset);
+  _checksum_buffer_sz += sizeof(_pm10_offset);
   _checksum_buffer_sz += sizeof(_reboot_count);
 
   if (_checksum_buffer != nullptr) {
@@ -255,6 +320,16 @@ void BoardPreference::create_checksum_prefs_buffer() {
   address += _spoofed_mac_addr.length();
   memcpy((_checksum_buffer + address), &_temperature_offset, sizeof(_temperature_offset));
   address += sizeof(_temperature_offset);
+  memcpy((_checksum_buffer + address), &_humidity_offset, sizeof(_humidity_offset));
+  address += sizeof(_humidity_offset);
+  memcpy((_checksum_buffer + address), &_co2_offset, sizeof(_co2_offset));
+  address += sizeof(_co2_offset);
+  memcpy((_checksum_buffer + address), &_eco2_offset, sizeof(_eco2_offset));
+  address += sizeof(_eco2_offset);
+  memcpy((_checksum_buffer + address), &_tvoc_offset, sizeof(_tvoc_offset));
+  address += sizeof(_tvoc_offset);
+  memcpy((_checksum_buffer + address), &_pm10_offset, sizeof(_pm10_offset));
+  address += sizeof(_pm10_offset);
   memcpy((_checksum_buffer + address), &_reboot_count, sizeof(_reboot_count));
   address += sizeof(_reboot_count);
 }

--- a/src/board_preference.h
+++ b/src/board_preference.h
@@ -140,7 +140,7 @@ class BoardPreference {
   /*
    * Return the temperature offset.
    */
-  int8_t get_temperature_offset() const { return _temperature_offset; }
+  int16_t get_temperature_offset() const { return _temperature_offset; }
 
   /*
    * Set the temperature offset.
@@ -148,7 +148,72 @@ class BoardPreference {
    * Returns false is the change cannot be applied
    * and leaves the values unchanged.
    */
-  bool set_temperature_offset(int offset);
+  bool set_temperature_offset(int16_t offset);
+
+  /*
+   * Return the humidity offset.
+   */
+  int16_t get_humidity_offset() const { return _humidity_offset; }
+
+  /*
+   * Set the humidity offset.
+   *
+   * Returns false is the change cannot be applied
+   * and leaves the values unchanged.
+   */
+  bool set_humidity_offset(int16_t offset);
+
+  /*
+   * Return the co2 offset.
+   */
+  int16_t get_co2_offset() const { return _co2_offset; }
+
+  /*
+   * Set the co2 offset.
+   *
+   * Returns false is the change cannot be applied
+   * and leaves the values unchanged.
+   */
+  bool set_co2_offset(int16_t offset);
+
+  /*
+   * Return the eco2 offset.
+   */
+  int16_t get_eco2_offset() const { return _eco2_offset; }
+
+  /*
+   * Set the eco2 offset.
+   *
+   * Returns false is the change cannot be applied
+   * and leaves the values unchanged.
+   */
+  bool set_eco2_offset(int16_t offset);
+
+  /*
+   * Return the tvoc offset.
+   */
+  int16_t get_tvoc_offset() const { return _tvoc_offset; }
+
+  /*
+   * Set the tvoc offset.
+   *
+   * Returns false is the change cannot be applied
+   * and leaves the values unchanged.
+   */
+  bool set_tvoc_offset(int16_t offset);
+
+  /*
+   * Return the pm10 offset.
+   */
+  int16_t get_pm10_offset() const { return _pm10_offset; }
+
+  /*
+   * Set the pm10 offset.
+   *
+   * Returns false is the change cannot be applied
+   * and leaves the values unchanged.
+   */
+  bool set_pm10_offset(int16_t offset);
 
   /*
    * Return the number of reboots performed by the board.
@@ -178,8 +243,13 @@ class BoardPreference {
   String   _board_location;
   String   _board_room;
   String   _spoofed_mac_addr;
-  uint8_t  _temperature_offset = 0;
   uint16_t _reboot_count       = 0;
+  int16_t  _temperature_offset = 0;
+  int16_t  _humidity_offset    = 0;
+  int16_t  _co2_offset         = 0;
+  int16_t  _eco2_offset        = 0;
+  int16_t  _tvoc_offset        = 0;
+  int16_t  _pm10_offset        = 0;
 
   // Checksum internal buffer.
   uint8_t *_checksum_buffer    = nullptr;

--- a/src/network/telnet.cpp
+++ b/src/network/telnet.cpp
@@ -2,7 +2,6 @@
 
 #include <Arduino.h>
 #include <ESPTelnet.h>
-#include <WString.h>
 
 #include "../board_preference.h"
 #include "../log.h"
@@ -40,6 +39,11 @@ static void cmd_board_location(String);
 static void cmd_board_room(String);
 static void cmd_mac_address(String);
 static void cmd_temp_offset(String);
+static void cmd_hum_offset(String);
+static void cmd_co2_offset(String);
+static void cmd_eco2_offset(String);
+static void cmd_tvoc_offset(String);
+static void cmd_pm10_offset(String);
 static void cmd_get_reboot_count(String);
 static void cmd_clear_reboot_count(String);
 static void cmd_uptime(String);
@@ -50,23 +54,28 @@ static void cmd_quit(String);
 static void cmd_help(String);
 
 static const TelnetCommand commands[] = {
-    {"sensor-info",    cmd_sensor_info,        "retrieve the values from all available sensors"        },
-    {"sensor-list",    cmd_sensor_list,        "list the available sensors"                            },
-    {"sensor-add",     cmd_sensor_add,         "mark a sensor as available"                            },
-    {"sensor-rm",      cmd_sensor_rm,          "mark a sensor as no longer available"                  },
-    {"board-host",     cmd_board_host,         "get or set board's host name"                          },
-    {"board-location", cmd_board_location,     "get or set board's location"                           },
-    {"board-room",     cmd_board_room,         "get or set board's room"                               },
-    {"board-mac",      cmd_mac_address,        "get or set MAC address (off to use default)"           },
-    {"temp-offset",    cmd_temp_offset,        "get or set offset subtracted by each temperature value"},
-    {"get-reboot",     cmd_get_reboot_count,   "get count of reboots performed by the device"          },
-    {"clear-reboot",   cmd_clear_reboot_count, "clear count of reboots performed by the device"        },
-    {"uptime",         cmd_uptime,             "get the time elapsed since the board's boot"           },
-    {"ping",           cmd_ping,               "ping the board"                                        },
-    {"reboot",         cmd_reboot,             "reboot the board"                                      },
-    {"version",        cmd_version,            "show current firmware version"                         },
-    {"quit",           cmd_quit,               "exit"                                                  },
-    {"help",           cmd_help,               "show this help message"                                },
+    {"sensor-info",    cmd_sensor_info,        "retrieve the values from all available sensors"},
+    {"sensor-list",    cmd_sensor_list,        "list the available sensors"                    },
+    {"sensor-add",     cmd_sensor_add,         "mark a sensor as available"                    },
+    {"sensor-rm",      cmd_sensor_rm,          "mark a sensor as no longer available"          },
+    {"board-host",     cmd_board_host,         "get or set board's host name"                  },
+    {"board-location", cmd_board_location,     "get or set board's location"                   },
+    {"board-room",     cmd_board_room,         "get or set board's room"                       },
+    {"board-mac",      cmd_mac_address,        "get or set MAC address (off to use default)"   },
+    {"temp-offset",    cmd_temp_offset,        "get or set offset of each temperature value"   },
+    {"hum-offset",     cmd_hum_offset,         "get or set offset of each humidity value"      },
+    {"co2-offset",     cmd_co2_offset,         "get or set offset of each CO2 value"           },
+    {"eco2-offset",    cmd_eco2_offset,        "get or set offset of each eCO2 value"          },
+    {"tvoc-offset",    cmd_tvoc_offset,        "get or set offset of each tvoc value"          },
+    {"pm10-offset",    cmd_pm10_offset,        "get or set offset of each PM 10 value"         },
+    {"get-reboot",     cmd_get_reboot_count,   "get count of reboots performed by the device"  },
+    {"clear-reboot",   cmd_clear_reboot_count, "clear count of reboots performed by the device"},
+    {"uptime",         cmd_uptime,             "get the time elapsed since the board's boot"   },
+    {"ping",           cmd_ping,               "ping the board"                                },
+    {"reboot",         cmd_reboot,             "reboot the board"                              },
+    {"version",        cmd_version,            "show current firmware version"                 },
+    {"quit",           cmd_quit,               "exit"                                          },
+    {"help",           cmd_help,               "show this help message"                        },
 };
 
 static void cmd_sensor_info(String _) {
@@ -176,16 +185,86 @@ static void cmd_mac_address(String mac_addr) {
   }
 }
 
-static void cmd_temp_offset(String temp_str) {
-  temp_str.trim();
-  if (temp_str.isEmpty()) {
+static void cmd_temp_offset(String str) {
+  str.trim();
+  if (str.isEmpty()) {
     app_traceln("cmd_temp_offset: wants to get current temperature offset");
     telnet.println(String(Preference.get_temperature_offset()));
   } else {
     app_traceln("cmd_temp_offset: wants to set temperature offset");
-    int temp_offset = (int)temp_str.toInt();
-    if (!Preference.set_temperature_offset(temp_offset)) {
+    int offset = (int)str.toInt();
+    if (!Preference.set_temperature_offset(offset)) {
       telnet.println("error setting temperature offset");
+    }
+  }
+}
+
+static void cmd_hum_offset(String str) {
+  str.trim();
+  if (str.isEmpty()) {
+    app_traceln("cmd_hum_offset: wants to get current humidity offset");
+    telnet.println(String(Preference.get_humidity_offset()));
+  } else {
+    app_traceln("cmd_hum_offset: wants to set humidity offset");
+    int offset = (int16_t)str.toInt();
+    if (!Preference.set_humidity_offset(offset)) {
+      telnet.println("error setting humidity offset");
+    }
+  }
+}
+
+static void cmd_co2_offset(String str) {
+  str.trim();
+  if (str.isEmpty()) {
+    app_traceln("cmd_co2_offset: wants to get current co2 offset");
+    telnet.println(String(Preference.get_co2_offset()));
+  } else {
+    app_traceln("cmd_co2_offset: wants to set co2 offset");
+    int offset = (int16_t)str.toInt();
+    if (!Preference.set_co2_offset(offset)) {
+      telnet.println("error setting co2 offset");
+    }
+  }
+}
+
+static void cmd_eco2_offset(String str) {
+  str.trim();
+  if (str.isEmpty()) {
+    app_traceln("cmd_eco2_offset: wants to get current eco2 offset");
+    telnet.println(String(Preference.get_eco2_offset()));
+  } else {
+    app_traceln("cmd_eco2_offset: wants to set eco2 offset");
+    int offset = (int16_t)str.toInt();
+    if (!Preference.set_eco2_offset(offset)) {
+      telnet.println("error setting eco2 offset");
+    }
+  }
+}
+
+static void cmd_tvoc_offset(String str) {
+  str.trim();
+  if (str.isEmpty()) {
+    app_traceln("cmd_tvoc_offset: wants to get current tvoc offset");
+    telnet.println(String(Preference.get_tvoc_offset()));
+  } else {
+    app_traceln("cmd_tvoc_offset: wants to set tvoc offset");
+    int offset = (int16_t)str.toInt();
+    if (!Preference.set_tvoc_offset(offset)) {
+      telnet.println("error setting tvoc offset");
+    }
+  }
+}
+
+static void cmd_pm10_offset(String str) {
+  str.trim();
+  if (str.isEmpty()) {
+    app_traceln("cmd_pm10_offset: wants to get current pm 10 offset");
+    telnet.println(String(Preference.get_pm10_offset()));
+  } else {
+    app_traceln("cmd_pm10_offset: wants to set pm 10 offset");
+    int offset = (int16_t)str.toInt();
+    if (!Preference.set_pm10_offset(offset)) {
+      telnet.println("error setting pm 10 offset");
     }
   }
 }

--- a/src/sensor/DHT11_sensor.cpp
+++ b/src/sensor/DHT11_sensor.cpp
@@ -23,11 +23,15 @@ bool DHT11_Sensor::on_measure() {
   _temperature = _dht.readTemperature();
   _humidity    = _dht.readHumidity();
 
-  // Remove temperature offset from data
-  app_traceln("DHT11_Sensor::measure: using offset of "
-              + String(Preference.get_temperature_offset()) + " for real temperature of "
-              + String(_temperature));
-  _temperature -= Preference.get_temperature_offset();
+  // Remove offset from data
+  int16_t temp_offset = Preference.get_temperature_offset();
+  int16_t hum_offset  = Preference.get_humidity_offset();
+  app_traceln("DHT11_Sensor::measure: using offset of " + String(temp_offset)
+              + " for real temperature of " + String(_temperature));
+  _temperature += temp_offset;
+  app_traceln("DHT11_Sensor::measure: using offset of " + String(hum_offset)
+              + " for real humidity of " + String(_humidity));
+  _humidity += hum_offset;
 
 #ifdef PRINT_SENSORS_ON_READ
   app_infoln("DHT11 temperature: " + String(_temperature));

--- a/src/sensor/MHZ19_sensor.cpp
+++ b/src/sensor/MHZ19_sensor.cpp
@@ -3,6 +3,7 @@
 #include <Arduino.h>
 #include <MHZCO2.h>
 
+#include "../board_preference.h"
 #include "../config.h"
 #include "../log.h"
 
@@ -57,6 +58,12 @@ bool MHZ19_Sensor::on_measure() {
     totalCo2 /= j;
   }
   _co2 = totalCo2;
+
+  // Remove offset from data
+  int16_t co2_offset = Preference.get_co2_offset();
+  app_traceln("MHZ19_Sensor::measure: using offset of " + String(co2_offset) + " for real CO2 of "
+              + String(_co2));
+  _co2 += temp_offset;
 
 #ifdef PRINT_SENSORS_ON_READ
   app_infoln("MHZ19 Co2: " + String(_co2));

--- a/src/sensor/MHZ19_sensor.cpp
+++ b/src/sensor/MHZ19_sensor.cpp
@@ -60,10 +60,10 @@ bool MHZ19_Sensor::on_measure() {
   _co2 = totalCo2;
 
   // Remove offset from data
-  int16_t co2_offset = Preference.get_co2_offset();
+  float co2_offset = Preference.get_co2_offset() * 0.01;
   app_traceln("MHZ19_Sensor::measure: using offset of " + String(co2_offset) + " for real CO2 of "
               + String(_co2));
-  _co2 += temp_offset;
+  _co2 *= round(co2_offset);
 
 #ifdef PRINT_SENSORS_ON_READ
   app_infoln("MHZ19 Co2: " + String(_co2));

--- a/src/sensor/MHZ19_sensor.h
+++ b/src/sensor/MHZ19_sensor.h
@@ -13,7 +13,7 @@
 #define MHZ19_MAX_CO2 5000
 // Number of iterations used to compute the mean CO2.
 #define MHZ19_AVG_NUM 10
-#define MHZ19_RANGE 5000
+#define MHZ19_RANGE   5000
 
 class MHZ19_Sensor : public AbstractSensor {
   public:

--- a/src/sensor/SGP30_sensor.cpp
+++ b/src/sensor/SGP30_sensor.cpp
@@ -4,6 +4,7 @@
 #include <Arduino.h>
 #include <WString.h>
 
+#include "../board_preference.h"
 #include "../config.h"
 #include "../log.h"
 
@@ -49,6 +50,16 @@ bool SGP30_Sensor::on_measure() {
   }
   _tvoc = totalTvoc;
   _eco2 = totalEco2;
+
+  // Remove offset from data
+  int16_t eco2_offset = Preference.get_eco2_offset();
+  int16_t tvoc_offset = Preference.get_tvoc_offset();
+  app_traceln("SGP30_Sensor::measure: using offset of " + String(eco2_offset) + " for real eCO2 of "
+              + String(_eco2));
+  _eco2 += eco2_offset;
+  app_traceln("SGP30_Sensor::measure: using offset of " + String(tvoc_offset) + " for real TVOC of "
+              + String(_tvoc));
+  _tvoc += tvoc_offset;
 
 #ifdef PRINT_SENSORS_ON_READ
   app_infoln("SGP30 TVOC: " + String(_tvoc));

--- a/src/sensor/SPS30_sensor.cpp
+++ b/src/sensor/SPS30_sensor.cpp
@@ -3,6 +3,7 @@
 #include <Arduino.h>
 #include <sps30.h>
 
+#include "../board_preference.h"
 #include "../config.h"
 #include "../log.h"
 
@@ -66,6 +67,12 @@ bool SPS30_Sensor::on_measure() {
     app_errorln("SPS30_Sensor::measure: error reading measurement");
     return false;
   }
+
+  // Remove offset from data
+  int16_t pm10_offset = Preference.get_pm10_offset();
+  app_traceln("SGP30_Sensor::measure: using offset of " + String(pm10_offset)
+              + " for real PM 10 of " + String(_sps_meas.mc_10p0));
+  _sps_meas.mc_10p0 += pm10_offset;
 
 #ifdef PRINT_SENSORS_ON_READ
   app_infoln("SPS30 PM 1.0: " + String(_sps_meas.mc_1p0));


### PR DESCRIPTION
This PR adds the ability to store an offset for each sensor read in the device.
Note: At the moment each sensor's offset is added or subtracted to the original value except for the CO2 that its treated like a scale (multiplied to the value).